### PR TITLE
Reproduce S14 panels j (example traces) and k (CDFs) side by side

### DIFF
--- a/code/generate_S14jk.py
+++ b/code/generate_S14jk.py
@@ -1,10 +1,17 @@
+"""Reproduce supplementary figure S14 panels j and k side by side.
+
+Panel j: raw example voltage traces for one example cell per projection target.
+Panel k: PC1 and membrane time constant cumulative distributions.
+Colors are shared between the two panels.
+"""
+
 import logging
 
 from LCNE_patchseq_analysis.data_util.metadata import load_ephys_metadata
 from LCNE_patchseq_analysis.pipeline_util.s3 import get_public_representative_spikes
 
 from LCNE_patchseq_analysis.figures import GLOBAL_FILTER
-from LCNE_patchseq_analysis.figures.main_pca_tau import figure_s14_cumulative
+from LCNE_patchseq_analysis.figures.main_pca_tau import figure_s14_jk
 
 # -- Physiological properties --
 logger = logging.getLogger(__name__)
@@ -19,7 +26,7 @@ logger.info(f"Loaded metadata with shape: {df_meta.shape}")
 logger.info("Loading spike waveforms...")
 df_spikes = get_public_representative_spikes("average")
 
-logger.info("Generating figure S14 (PC1 and time constant cumulative distributions)...")
-fig, axes_dict, results, csv_data = figure_s14_cumulative(
+logger.info("Generating figure S14 panels j (example traces) and k (cumulative distributions)...")
+fig, axes_dict, results, csv_data = figure_s14_jk(
     df_meta, df_spikes, filtered_df_meta=df_meta
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     'matplotlib',
     'seaborn',
     'h5py',
+    'tables',
     's3fs',
     'requests',
     'trimesh',
@@ -46,7 +47,6 @@ dev = [
 
 efel = [
     'efel',
-    'tables',
 ]
 
 [tool.setuptools.packages.find]

--- a/src/LCNE_patchseq_analysis/figures/__init__.py
+++ b/src/LCNE_patchseq_analysis/figures/__init__.py
@@ -39,6 +39,14 @@ DEFAULT_AREA_ORDER = [
     "cerebellum",
 ]
 
+# Shared colors for the three projection targets, used consistently across the
+# example-trace panel (S14j) and the cumulative-distribution panel (S14k).
+PROJECTION_COLORS = {
+    "Cortex": "#5b2a86",  # purple
+    "Cerebellum": "#e2703a",  # orange
+    "Spinal cord": "#f2b705",  # gold
+}
+
 # Default ephys feature mapping
 DEFAULT_EPHYS_FEATURES = [
     # Manually selected ephys features to include in ANOVA analysis, multiple comparison correction,

--- a/src/LCNE_patchseq_analysis/figures/example_traces.py
+++ b/src/LCNE_patchseq_analysis/figures/example_traces.py
@@ -1,0 +1,152 @@
+"""Raw example voltage traces for the three projection-target example cells (S14j).
+
+Reads the raw peri-stimulus voltage sweeps straight out of the per-cell eFEL
+feature .h5 files (no NWB access needed) and plots, for each example cell, a
+suprathreshold spiking sweep on top and a near-rheobase sweep overlaid with the
+most-hyperpolarized subthreshold sweep below — one column per projection target.
+"""
+
+import logging
+import os
+
+import numpy as np
+import pandas as pd
+
+from LCNE_patchseq_analysis import RESULTS_DIRECTORY, TIME_STEP
+from LCNE_patchseq_analysis.figures import PROJECTION_COLORS
+
+logger = logging.getLogger(__name__)
+
+FEATURES_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "../../../data/LCNE-patchseq-ephys/efel/features",
+)
+
+# Example cell per projection target, in display order. `region` keys into
+# PROJECTION_COLORS so the trace colors match the S14k CDF panels.
+EXAMPLE_CELLS = [
+    {"label": "Isocortex", "region": "Cortex", "ephys_roi_id": "1388239233"},
+    {"label": "Cerebellum", "region": "Cerebellum", "ephys_roi_id": "1426757704"},
+    {"label": "Spinal cord", "region": "Spinal cord", "ephys_roi_id": "1410640556"},
+]
+
+# Vertical offset (mV) applied to the suprathreshold sweep so it sits above the
+# rheobase / hyperpolarizing sweeps, mirroring the published layout.
+SUPRA_OFFSET_MV = 120.0
+
+
+def load_features(ephys_roi_id: str) -> dict:
+    """Load the dict of DataFrames from a per-cell eFEL feature .h5 file."""
+    path = os.path.join(FEATURES_DIR, f"{ephys_roi_id}_efel.h5")
+    out = {}
+    with pd.HDFStore(path, mode="r") as store:
+        for key in store.keys():
+            out[key.replace("/", "")] = store[key]
+    return out
+
+
+def _select_sweep(df, contains, stim_name, need_spikes, pick="min_abs_amp"):
+    """Return one sweep_number matching the stimulus criteria, or None."""
+    mask = (
+        df["stimulus_code"].str.contains(contains)
+        & (df["stimulus_name"] == stim_name)
+    )
+    if need_spikes:
+        mask &= df["spike_count"] > 0
+    sub = df[mask]
+    if sub.empty:
+        return None
+    if pick == "min_abs_amp":
+        row = sub.loc[sub["stimulus_amplitude"].abs().idxmin()]
+    elif pick == "max_abs_amp":
+        row = sub.loc[sub["stimulus_amplitude"].abs().idxmax()]
+    else:
+        raise ValueError(pick)
+    return int(row["sweep_number"])
+
+
+def select_sweeps(features: dict) -> dict:
+    """Pick the suprathreshold, rheobase, and hyperpolarizing sweeps to plot."""
+    df = features["df_features_per_sweep"].merge(
+        features["df_sweeps"], on="sweep_number"
+    )
+    return {
+        "supra": _select_sweep(df, "SupraThresh", "Long Square", True),
+        "rheo": _select_sweep(df, "Rheo", "Long Square", True),
+        "hyperpol": _select_sweep(df, "SubThresh", "Long Square", False, "max_abs_amp"),
+    }
+
+
+def plot_cell(ax, features: dict, sweeps: dict, color: str, linewidth: float = 1.0):
+    """Plot the selected sweeps for one cell into ax."""
+    raw = features["df_peri_stimulus_raw_traces"]
+
+    def get_v(sweep_number):
+        if sweep_number is None:
+            return None, None
+        row = raw.query("sweep_number == @sweep_number")
+        if row.empty:
+            return None, None
+        v = np.asarray(row["V"].iloc[0], dtype=float)
+        t = np.arange(len(v)) * TIME_STEP
+        return t, v
+
+    # Bottom: near-rheobase sweep overlaid with the hyperpolarizing sweep.
+    for key in ("hyperpol", "rheo"):
+        t, v = get_v(sweeps[key])
+        if v is not None:
+            ax.plot(t, v, color=color, lw=linewidth)
+
+    # Top: suprathreshold spiking sweep, offset upward for clarity.
+    t, v = get_v(sweeps["supra"])
+    if v is not None:
+        ax.plot(t, v + SUPRA_OFFSET_MV, color=color, lw=linewidth)
+
+    ax.axis("off")
+
+
+def add_scale_bar(ax, x_ms=200, y_mv=50, x0=0.02, y0=0.05):
+    """Draw an L-shaped scale bar (time, voltage) in axes-fraction coords."""
+    (x_lo, x_hi), (y_lo, y_hi) = ax.get_xlim(), ax.get_ylim()
+    x_span, y_span = x_hi - x_lo, y_hi - y_lo
+    xs = x_lo + x0 * x_span
+    ys = y_lo + y0 * y_span
+    ax.plot([xs, xs], [ys, ys + y_mv], color="black", lw=1.5)
+    ax.plot([xs, xs + x_ms], [ys, ys], color="black", lw=1.5)
+    ax.text(xs - 0.01 * x_span, ys + y_mv / 2, f"{y_mv} mV",
+            ha="right", va="center", fontsize=9, rotation=90)
+    ax.text(xs + x_ms / 2, ys - 0.02 * y_span, f"{x_ms} ms",
+            ha="center", va="top", fontsize=9)
+
+
+def plot_example_traces(axes, cells=EXAMPLE_CELLS, add_scalebar: bool = True):
+    """Draw the example-trace column for each cell into the provided axes.
+
+    Parameters
+    ----------
+    axes : sequence of matplotlib axes
+        One axis per cell (same length as `cells`). Y-limits are shared so the
+        scale bar on the first axis applies to all.
+    cells : list of dict
+        Each dict has 'label', 'region' (key into PROJECTION_COLORS), and
+        'ephys_roi_id'.
+    add_scalebar : bool
+        Whether to draw an L-shaped scale bar on the first axis.
+    """
+    axes = np.atleast_1d(axes)
+    for ax, cell in zip(axes, cells):
+        logger.info(f"Plotting {cell['label']} ({cell['ephys_roi_id']})...")
+        features = load_features(cell["ephys_roi_id"])
+        sweeps = select_sweeps(features)
+        logger.info(f"  selected sweeps: {sweeps}")
+        plot_cell(ax, features, sweeps, PROJECTION_COLORS[cell["region"]])
+        ax.set_title(cell["label"], fontsize=13)
+
+    # Share y-limits across all cells so one scale bar is valid for the row.
+    y_lo = min(ax.get_ylim()[0] for ax in axes)
+    y_hi = max(ax.get_ylim()[1] for ax in axes)
+    for ax in axes:
+        ax.set_ylim(y_lo, y_hi)
+
+    if add_scalebar:
+        add_scale_bar(axes[0])

--- a/src/LCNE_patchseq_analysis/figures/main_pca_tau.py
+++ b/src/LCNE_patchseq_analysis/figures/main_pca_tau.py
@@ -19,7 +19,11 @@ from sklearn.decomposition import PCA
 
 from LCNE_patchseq_analysis import REGION_COLOR_MAPPER
 from LCNE_patchseq_analysis.data_util.mesh import plot_mesh
-from LCNE_patchseq_analysis.figures import set_plot_style, sort_region
+from LCNE_patchseq_analysis.figures import PROJECTION_COLORS, set_plot_style, sort_region
+from LCNE_patchseq_analysis.figures.example_traces import (
+    EXAMPLE_CELLS,
+    plot_example_traces,
+)
 from LCNE_patchseq_analysis.figures.util import save_figure
 from LCNE_patchseq_analysis.pipeline_util.s3 import (
     get_public_representative_spikes,
@@ -809,13 +813,145 @@ def figure_s14_cumulative(
     return fig, axes_dict, results, csv_data
 
 
+def _plot_s14k_cdfs(cdf_axes, df_v_proj, tau_col):
+    """Draw the two S14k cumulative-distribution panels (PC1, membrane tau).
+
+    Returns (pc1_groups, tau_groups) for downstream CSV export.
+    """
+    pc1_groups = _build_projection_groups(df_v_proj, "PCA1")
+    tau_groups = _build_projection_groups(df_v_proj, tau_col)
+
+    ax = cdf_axes[0]
+    _plot_group_cdf(ax, pc1_groups)
+    ax.set_title("PC1")
+    ax.set_xlabel("PC1")
+
+    ax = cdf_axes[1]
+    _plot_group_cdf(ax, tau_groups)
+    ax.set_title("Membrane time constant")
+    ax.set_xlabel("Membrane time constant (ms)")
+
+    return pc1_groups, tau_groups
+
+
+def figure_s14_jk(
+    df_meta: pd.DataFrame,
+    df_spikes: pd.DataFrame | None = None,
+    spike_type: str = DEFAULT_SPIKE_TYPE,
+    extract_from: str = DEFAULT_EXTRACT_FROM,
+    spike_range: tuple = DEFAULT_SPIKE_RANGE,
+    normalize_window_v: tuple = DEFAULT_NORMALIZE_WINDOW_V,
+    normalize_window_dvdt: tuple = DEFAULT_NORMALIZE_WINDOW_DVDT,
+    filtered_df_meta: pd.DataFrame | None = None,
+    if_save_figure: bool = True,
+    if_save_csv: bool = True,
+    filename: str = "S14jk",
+    figsize: tuple = (20, 4.5),
+):
+    """Generate supplementary figure S14 panels j and k side-by-side.
+
+    Panel j (left): raw example voltage traces for one example cell per
+    projection target (spiking sweep offset above a near-rheobase sweep overlaid
+    with the most-hyperpolarized subthreshold sweep). Panel k (right): PC1 and
+    membrane time constant cumulative distributions split by projection target.
+    Colors are shared between j and k via PROJECTION_COLORS.
+
+    Parameters
+    ----------
+    df_meta, df_spikes, spike_type, extract_from, spike_range,
+    normalize_window_v, normalize_window_dvdt, filtered_df_meta :
+        Analysis parameters for panel k (see spike_pca_analysis).
+    if_save_figure, if_save_csv, filename, figsize :
+        Output controls.
+
+    Returns
+    -------
+    (fig, axes_dict, results, csv_data)
+    """
+    set_plot_style(base_size=12)
+
+    results = spike_pca_analysis(
+        df_meta=df_meta,
+        df_spikes=df_spikes,
+        spike_type=spike_type,
+        extract_from=extract_from,
+        spike_range=spike_range,
+        normalize_window_v=normalize_window_v,
+        normalize_window_dvdt=normalize_window_dvdt,
+        filtered_df_meta=filtered_df_meta,
+    )
+    df_v_proj = results["df_v_proj"]
+    tau_col = results["tau_col"]
+
+    # Layout: panel j (3 trace columns) | panel k (2 CDF columns).
+    fig = plt.figure(figsize=figsize)
+    gs = fig.add_gridspec(1, 2, width_ratios=[3, 2], wspace=0.18)
+    gs_j = gs[0].subgridspec(1, len(EXAMPLE_CELLS), wspace=0.05)
+    gs_k = gs[1].subgridspec(1, 2, wspace=0.4)
+    trace_axes = [fig.add_subplot(gs_j[0, i]) for i in range(len(EXAMPLE_CELLS))]
+    cdf_axes = [fig.add_subplot(gs_k[0, i]) for i in range(2)]
+
+    axes_dict = {}
+
+    # Panel j: raw example traces.
+    plot_example_traces(trace_axes)
+    for i, ax in enumerate(trace_axes):
+        axes_dict[f"trace_{EXAMPLE_CELLS[i]['label']}"] = ax
+    # Center the header over the trace panels (panel j) only.
+    j_center = 0.5 * (
+        trace_axes[0].get_position().x0 + trace_axes[-1].get_position().x1
+    )
+    fig.text(
+        j_center, 1.0, "LC-NE projections to:", ha="center", va="top",
+        fontsize=13, style="italic",
+    )
+
+    # Panel k: cumulative distributions.
+    pc1_groups, tau_groups = _plot_s14k_cdfs(cdf_axes, df_v_proj, tau_col)
+    axes_dict["pca1_cdf"] = cdf_axes[0]
+    axes_dict["tau_cdf"] = cdf_axes[1]
+
+    # Panel letters.
+    trace_axes[0].annotate(
+        "j", xy=(0, 1.05), xycoords="axes fraction",
+        fontsize=18, fontweight="bold", ha="right", va="bottom",
+    )
+    cdf_axes[0].annotate(
+        "k", xy=(-0.25, 1.05), xycoords="axes fraction",
+        fontsize=18, fontweight="bold", ha="right", va="bottom",
+    )
+
+    csv_data = {
+        f"{filename}_PC1_raw": _raw_underlying_data(df_v_proj, "PCA1", "PC1"),
+        f"{filename}_PC1_cumulative": _cdf_underlying_data(pc1_groups, "PC1"),
+        f"{filename}_membrane_time_constant_raw": _raw_underlying_data(
+            df_v_proj, tau_col, "membrane_time_constant_ms"
+        ),
+        f"{filename}_membrane_time_constant_cumulative": _cdf_underlying_data(
+            tau_groups, "membrane_time_constant_ms"
+        ),
+    }
+
+    if if_save_figure:
+        save_figure(fig, filename=filename, formats=("png", "svg"), bbox_inches="tight")
+
+    if if_save_csv:
+        output_dir = _resolve_output_dir()
+        for name, data in csv_data.items():
+            out_path = os.path.join(output_dir, f"{name}.csv")
+            data.to_csv(out_path, index=False)
+            logger.info(f"Underlying data saved as: {out_path}")
+
+    return fig, axes_dict, results, csv_data
+
+
 def _build_projection_groups(df_v_proj, value_col):
     """Build (label, values, color, n_mice) groups for spinal cord, cortex, and CB."""
     groups = []
     for grp_label, region_set, color in [
-        ("Spinal cord", SPINAL_REGIONS, REGION_COLOR_MAPPER["Spinal cord"]),
-        ("Cortex", CORTEX_REGIONS, REGION_COLOR_MAPPER["Cortex"]),
-        ("Cerebellum", CB_REGIONS, REGION_COLOR_MAPPER["Cerebellum"]),
+        ("Spinal cord", SPINAL_REGIONS, PROJECTION_COLORS["Spinal cord"]),
+        ("Cortex", CORTEX_REGIONS, PROJECTION_COLORS["Cortex"]),
+        ("Cerebellum", CB_REGIONS, PROJECTION_COLORS["Cerebellum"]),
     ]:
         mask = df_v_proj["injection region"].isin(region_set)
         vals_series = pd.Series(


### PR DESCRIPTION
Add raw example voltage traces (panel j) for one example cell per projection target next to the PC1 / membrane time constant cumulative distributions (panel k), with colors shared between the two panels.

- Add figures/example_traces.py: reads raw peri-stimulus sweeps straight from the per-cell eFEL .h5 files (no NWB needed) and plots one column per example cell (cortex 1388239233, cerebellum 1426757704, spinal cord 1410640556): a suprathreshold spiking sweep offset above a near-rheobase sweep overlaid with the most-hyperpolarized subthreshold sweep, plus an L-shaped scale bar.
- Add PROJECTION_COLORS (purple/orange/gold) to figures/__init__.py and use it for the CDF groups so panels j and k match.
- Add figure_s14_jk() to main_pca_tau.py laying out j and k side by side.
- Rename generate_main_figures.py -> generate_S14jk.py.
- Promote 'tables' to a core dependency (needed to read the .h5 feature files).